### PR TITLE
Add product manager CV web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # CV
+
+A simple CV web page for a cool product manager. Open `index.html` in your browser to view.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alex Johnson - Product Manager</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>Alex Johnson</h1>
+      <p>Cool Product Manager</p>
+    </div>
+  </header>
+  <main class="container">
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Innovative product manager with 8+ years of experience turning visionary ideas into user-centric products.</p>
+    </section>
+    <section id="experience">
+      <h2>Experience</h2>
+      <div class="job">
+        <h3>Senior Product Manager, TechCorp</h3>
+        <span class="date">2019 - Present</span>
+        <p>Leading cross-functional teams to deliver mobile experiences serving over 2M users.</p>
+      </div>
+      <div class="job">
+        <h3>Product Manager, StartApp</h3>
+        <span class="date">2015 - 2019</span>
+        <p>Launched the company’s flagship SaaS platform and drove 40% YoY revenue growth.</p>
+      </div>
+    </section>
+    <section id="projects">
+      <h2>Projects</h2>
+      <ul>
+        <li>Built AI-powered analytics dashboard reducing churn by 15%.</li>
+        <li>Introduced Agile roadmap process adopted company-wide.</li>
+      </ul>
+    </section>
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul class="skills-list">
+        <li>Product Strategy</li>
+        <li>User Research</li>
+        <li>Data Analysis</li>
+        <li>Stakeholder Communication</li>
+        <li>Agile Leadership</li>
+      </ul>
+    </section>
+    <section id="education">
+      <h2>Education</h2>
+      <p>B.S. in Computer Science, State University, 2014</p>
+    </section>
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:alex.johnson@example.com">alex.johnson@example.com</a></p>
+      <p>LinkedIn: <a href="https://www.linkedin.com/in/alexjohnson">linkedin.com/in/alexjohnson</a></p>
+    </section>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2023 Alex Johnson</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,75 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f4f4f4;
+  color: #333;
+}
+
+header {
+  background: #2c3e50;
+  color: #fff;
+  padding: 40px 0;
+  text-align: center;
+}
+
+.container {
+  width: 90%;
+  max-width: 900px;
+  margin: auto;
+}
+
+section {
+  background: #fff;
+  margin: 20px 0;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+h2 {
+  border-bottom: 2px solid #2c3e50;
+  padding-bottom: 5px;
+  margin-bottom: 15px;
+}
+
+.job {
+  margin-bottom: 15px;
+}
+
+.job .date {
+  font-size: 0.9em;
+  color: #777;
+}
+
+.skills-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.skills-list li {
+  background: #2c3e50;
+  color: #fff;
+  padding: 5px 10px;
+  border-radius: 4px;
+  margin: 5px;
+}
+
+footer {
+  text-align: center;
+  padding: 10px 0;
+  background: #2c3e50;
+  color: #fff;
+  margin-top: 20px;
+}
+
+a {
+  color: #2c3e50;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Add a responsive `index.html` showcasing a product manager's CV with experience, skills, and contact info
- Style the page via `styles.css` for a clean layout and dark header
- Document usage in an updated `README.md`

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6897221733bc832ca062629654a6b1ef