### PR TITLE
Enhance CV readability and contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,7 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
   margin: 0;
   padding: 0;
   background: linear-gradient(135deg, #e0eafc 0%, #cfdef3 100%);
@@ -23,10 +25,10 @@ header .contact {
 }
 
 .glass {
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.6);
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 8px 32px rgba(31, 38, 135, 0.37);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 8px 32px rgba(31, 38, 135, 0.2);
   backdrop-filter: blur(10px) saturate(180%);
   -webkit-backdrop-filter: blur(10px) saturate(180%);
 }
@@ -59,14 +61,22 @@ h2 {
 }
 
 .skills-list li {
-  background: rgba(255, 255, 255, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(4px) saturate(180%);
   -webkit-backdrop-filter: blur(4px) saturate(180%);
   color: #1a1a1a;
   padding: 5px 10px;
   border-radius: 12px;
   margin: 5px;
+}
+
+.job ul li {
+  margin-bottom: 8px;
+}
+
+.job ul li:last-child {
+  margin-bottom: 0;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- Improve overall readability with a base font size and line height.
- Increase glass background opacity and contrast for clearer text.
- Strengthen skill badge visibility and add spacing to bullet lists.

## Testing
- `npm test` *(fails: ENOENT no such file or directory, open '/workspace/CV/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68972dec022c832caeb0288c5bd6bed0