### PR TITLE
Add dark/light theme toggle with auto detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ilya Zubkov - Product Owner</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
+  <script>
+    const storedTheme = localStorage.getItem('theme');
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', storedTheme || systemTheme);
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+<button id="theme-toggle" aria-label="Toggle dark/light mode"></button>
 <header class="glass">
   <div class="container">
     <h1>Ilya Zubkov</h1>

--- a/script.js
+++ b/script.js
@@ -12,4 +12,15 @@ document.addEventListener('DOMContentLoaded', () => {
     el.classList.add('hidden');
     observer.observe(el);
   });
+
+  const themeToggle = document.getElementById('theme-toggle');
+  const currentTheme = document.documentElement.getAttribute('data-theme');
+  themeToggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
+
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+    themeToggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,39 @@
+:root {
+  color-scheme: light;
+  --bg-gradient: linear-gradient(135deg, #f0f0f0 0%, #cccccc 100%);
+  --text-color: #1e1e1e;
+  --link-color: #1e88e5;
+  --glass-bg: rgba(255, 255, 255, 0.6);
+  --glass-border: rgba(0, 0, 0, 0.1);
+  --glass-shadow: rgba(0, 0, 0, 0.1);
+  --skills-bg: rgba(0, 0, 0, 0.05);
+  --skills-border: rgba(0, 0, 0, 0.1);
+  --date-color: #666;
+  --h2-border: rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg-gradient: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
+  --text-color: #f0f0f0;
+  --link-color: #4dabf7;
+  --glass-bg: rgba(0, 0, 0, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-shadow: rgba(0, 0, 0, 0.5);
+  --skills-bg: rgba(255, 255, 255, 0.1);
+  --skills-border: rgba(255, 255, 255, 0.2);
+  --date-color: #bbb;
+  --h2-border: rgba(255, 255, 255, 0.2);
+}
+
 body {
   font-family: 'Roboto', sans-serif;
   font-size: 16px;
   line-height: 1.6;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
-  color: #f0f0f0;
+  background: var(--bg-gradient);
+  color: var(--text-color);
 }
 
 header {
@@ -25,10 +53,10 @@ header .contact {
 }
 
 .glass {
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--glass-bg);
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 8px 32px var(--glass-shadow);
   backdrop-filter: blur(10px) saturate(180%);
   -webkit-backdrop-filter: blur(10px) saturate(180%);
 }
@@ -39,7 +67,7 @@ section {
 }
 
 h2 {
-  border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 2px solid var(--h2-border);
   padding-bottom: 5px;
   margin-bottom: 15px;
 }
@@ -50,7 +78,7 @@ h2 {
 
 .job .date {
   font-size: 0.9em;
-  color: #bbb;
+  color: var(--date-color);
 }
 
 .skills-list {
@@ -61,11 +89,11 @@ h2 {
 }
 
 .skills-list li {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: var(--skills-bg);
+  border: 1px solid var(--skills-border);
   backdrop-filter: blur(4px) saturate(180%);
   -webkit-backdrop-filter: blur(4px) saturate(180%);
-  color: #f0f0f0;
+  color: var(--text-color);
   padding: 5px 10px;
   border-radius: 12px;
   margin: 5px;
@@ -86,12 +114,28 @@ footer {
 }
 
 a {
-  color: #4dabf7;
+  color: var(--link-color);
   text-decoration: none;
 }
 
 a:hover {
   text-decoration: underline;
+}
+
+#theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-color);
 }
 
 .hidden {
@@ -104,3 +148,4 @@ a:hover {
   opacity: 1;
   transform: translateY(0);
 }
+


### PR DESCRIPTION
## Summary
- add automatic detection of system color scheme
- allow users to toggle between dark and light modes with stored preference
- refactor styles to support both themes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973e37c700832c9bb07dce619fb40f