### PR TITLE
Ensure theme toggle is always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<button id="theme-toggle" aria-label="Toggle dark/light mode"></button>
+<button id="theme-toggle" aria-label="Toggle dark/light mode">🌙</button>
 <header class="glass">
   <div class="container">
     <h1>Ilya Zubkov</h1>

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,7 @@ a:hover {
   justify-content: center;
   cursor: pointer;
   color: var(--text-color);
+  z-index: 1000;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- Show a default icon on the theme toggle to avoid initial blank button
- Raise the toggle's z-index so it stays above other content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689743846bcc832c80aeddb22c58a005