### PR TITLE
Add interactive tilt animations for resume blocks

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,21 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.glass').forEach((el) => {
     el.classList.add('hidden');
     observer.observe(el);
+
+    el.addEventListener('mousemove', (e) => {
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const rotateY = ((x / rect.width) - 0.5) * 10;
+      const rotateX = ((y / rect.height) - 0.5) * -10;
+      el.style.setProperty('--rotateX', `${rotateX}deg`);
+      el.style.setProperty('--rotateY', `${rotateY}deg`);
+    });
+
+    el.addEventListener('mouseleave', () => {
+      el.style.setProperty('--rotateX', '0deg');
+      el.style.setProperty('--rotateY', '0deg');
+    });
   });
 
   const themeToggle = document.getElementById('theme-toggle');

--- a/styles.css
+++ b/styles.css
@@ -59,11 +59,20 @@ header .contact {
   box-shadow: 0 8px 32px var(--glass-shadow);
   backdrop-filter: blur(10px) saturate(180%);
   -webkit-backdrop-filter: blur(10px) saturate(180%);
+  --translateY: 0px;
+  --hover-translate: 0px;
+  --rotateX: 0deg;
+  --rotateY: 0deg;
+  --scale: 1;
   transition: opacity 0.6s ease-out, transform 0.6s ease-out, box-shadow 0.3s ease;
+  transform: perspective(600px) translateY(calc(var(--translateY) + var(--hover-translate)))
+    rotateX(var(--rotateX)) rotateY(var(--rotateY)) scale(var(--scale));
+  transform-style: preserve-3d;
 }
 
 .glass:hover {
-  transform: translateY(-5px) scale(1.02);
+  --hover-translate: -5px;
+  --scale: 1.02;
   box-shadow: 0 12px 40px var(--glass-shadow);
 }
 
@@ -146,11 +155,11 @@ a:hover {
 
 .hidden {
   opacity: 0;
-  transform: translateY(20px);
+  --translateY: 20px;
 }
 
 .visible {
   opacity: 1;
-  transform: translateY(0);
+  --translateY: 0px;
 }
 


### PR DESCRIPTION
## Summary
- Add tilt-based hover animation driven by mouse movement for all `.glass` blocks
- Use CSS custom properties to combine scroll, hover, and tilt transforms
- Update visibility classes to leverage transform variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689743b5c8d4832cac193081d72ade52