### PR TITLE
Add dedicated languages section with Russian

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,9 +131,17 @@
     <li>B.Ed. in Computer Software Engineering, Odesa National Polytechnic University</li>
   </ul>
 </section>
+<section id="languages" class="glass">
+  <h2>Languages</h2>
+  <ul class="skills-list">
+    <li>English (C1)</li>
+    <li>Ukrainian (native)</li>
+    <li>Russian (native)</li>
+    <li>German (B2)</li>
+  </ul>
+</section>
 <section id="additional" class="glass">
   <h2>Additional Information</h2>
-  <p><strong>Languages:</strong> English (C1), Ukrainian (native), German (B2)</p>
   <p><strong>Technologies:</strong> C#, Unity, Git/GitHub, SQL, Algorithms, UML, Stripe, Gaming with dopamine dynamics</p>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- create a dedicated languages section showing English (C1), Ukrainian (native), Russian (native), and German (B2)
- move technology list to Additional Information

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689743e91380832c9cc018321811f43c