### PR TITLE
feat: add animation toggle and disclaimer

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 </head>
 <body>
 <button id="theme-toggle" aria-label="Toggle dark/light mode">🌙</button>
+<button id="animation-toggle" aria-label="Toggle animations">💫</button>
+<p class="disclaimer">This page has cool animations. Use the top-right button to turn them off.</p>
 <header class="glass">
   <div class="container">
     <h1>Ilya Zubkov</h1>

--- a/script.js
+++ b/script.js
@@ -1,34 +1,80 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('visible');
-        entry.target.classList.remove('hidden');
-      } else {
-        entry.target.classList.remove('visible');
-        entry.target.classList.add('hidden');
-      }
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          entry.target.classList.remove('hidden');
+        } else {
+          entry.target.classList.remove('visible');
+          entry.target.classList.add('hidden');
+        }
+      });
+    },
+    { threshold: 0.1 }
+  );
+
+  const handleMouseMove = (e) => {
+    const el = e.currentTarget;
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const rotateY = (x / rect.width - 0.5) * 10;
+    const rotateX = (y / rect.height - 0.5) * -10;
+    el.style.setProperty('--rotateX', `${rotateX}deg`);
+    el.style.setProperty('--rotateY', `${rotateY}deg`);
+  };
+
+  const handleMouseLeave = (e) => {
+    const el = e.currentTarget;
+    el.style.setProperty('--rotateX', '0deg');
+    el.style.setProperty('--rotateY', '0deg');
+  };
+
+  const animationToggle = document.getElementById('animation-toggle');
+  let animationsEnabled = localStorage.getItem('animations') !== 'off';
+
+  function enableAnimations() {
+    document.body.classList.remove('no-animations');
+    document.querySelectorAll('.glass').forEach((el) => {
+      el.classList.add('hidden');
+      observer.observe(el);
+      el.addEventListener('mousemove', handleMouseMove);
+      el.addEventListener('mouseleave', handleMouseLeave);
     });
-  }, { threshold: 0.1 });
+    animationToggle.textContent = '💫';
+    animationsEnabled = true;
+    localStorage.setItem('animations', 'on');
+  }
 
-  document.querySelectorAll('.glass').forEach((el) => {
-    el.classList.add('hidden');
-    observer.observe(el);
-
-    el.addEventListener('mousemove', (e) => {
-      const rect = el.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const rotateY = ((x / rect.width) - 0.5) * 10;
-      const rotateX = ((y / rect.height) - 0.5) * -10;
-      el.style.setProperty('--rotateX', `${rotateX}deg`);
-      el.style.setProperty('--rotateY', `${rotateY}deg`);
-    });
-
-    el.addEventListener('mouseleave', () => {
+  function disableAnimations() {
+    document.body.classList.add('no-animations');
+    observer.disconnect();
+    document.querySelectorAll('.glass').forEach((el) => {
+      el.classList.remove('hidden');
+      el.classList.add('visible');
+      el.removeEventListener('mousemove', handleMouseMove);
+      el.removeEventListener('mouseleave', handleMouseLeave);
       el.style.setProperty('--rotateX', '0deg');
       el.style.setProperty('--rotateY', '0deg');
     });
+    animationToggle.textContent = '🛑';
+    animationsEnabled = false;
+    localStorage.setItem('animations', 'off');
+  }
+
+  if (animationsEnabled) {
+    enableAnimations();
+  } else {
+    disableAnimations();
+  }
+
+  animationToggle.addEventListener('click', () => {
+    if (animationsEnabled) {
+      disableAnimations();
+    } else {
+      enableAnimations();
+    }
   });
 
   const themeToggle = document.getElementById('theme-toggle');
@@ -36,9 +82,13 @@ document.addEventListener('DOMContentLoaded', () => {
   themeToggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
 
   themeToggle.addEventListener('click', () => {
-    const newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    const newTheme =
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'light'
+        : 'dark';
     document.documentElement.setAttribute('data-theme', newTheme);
     localStorage.setItem('theme', newTheme);
     themeToggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
   });
 });
+

--- a/styles.css
+++ b/styles.css
@@ -154,6 +154,40 @@ a:hover {
   z-index: 1000;
 }
 
+#animation-toggle {
+  position: fixed;
+  top: 20px;
+  right: 70px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-color);
+  z-index: 1000;
+}
+
+.disclaimer {
+  text-align: center;
+  font-size: 0.9em;
+  margin: 10px;
+}
+
+.no-animations .glass {
+  transition: none !important;
+  transform: none !important;
+}
+
+.no-animations .hidden,
+.no-animations .visible {
+  opacity: 1 !important;
+  --translateY: 0px !important;
+}
+
 .hidden {
   opacity: 0;
   --translateY: 20px;


### PR DESCRIPTION
## Summary
- allow animations to be disabled with a new top-right toggle and localStorage persistence
- display a disclaimer explaining that animations can be turned off
- style new control and no-animation mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689747378de4832c89f86d694195d9ca