### PR TITLE
Show disclaimer as popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
 <body>
 <button id="theme-toggle" aria-label="Toggle dark/light mode">🌙</button>
 <button id="animation-toggle" aria-label="Toggle animations">💫</button>
-<p class="disclaimer">This page has cool animations. Use the top-right button to turn them off.</p>
+<dialog id="disclaimer-modal">
+  <p>This page has cool animations. Use the top-right button to turn them off.</p>
+  <button id="disclaimer-close" aria-label="Close disclaimer">OK</button>
+</dialog>
 <header class="glass">
   <div class="container">
     <h1>Ilya Zubkov</h1>

--- a/script.js
+++ b/script.js
@@ -105,5 +105,12 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('theme', newTheme);
     themeToggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
   });
+
+  const disclaimerModal = document.getElementById('disclaimer-modal');
+  const disclaimerClose = document.getElementById('disclaimer-close');
+  if (disclaimerModal) {
+    disclaimerModal.showModal();
+    disclaimerClose.addEventListener('click', () => disclaimerModal.close());
+  }
 });
 

--- a/styles.css
+++ b/styles.css
@@ -189,10 +189,16 @@ a:hover {
   z-index: 1000;
 }
 
-.disclaimer {
-  text-align: center;
-  font-size: 0.9em;
-  margin: 10px;
+#disclaimer-modal {
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  background: var(--glass-bg);
+  color: var(--text-color);
+  padding: 20px;
+}
+
+#disclaimer-modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .no-animations .glass {


### PR DESCRIPTION
## Summary
- Display disclaimer text in a modal dialog that opens when the page loads.
- Hook script to show and close the disclaimer popup on visit.
- Style the disclaimer dialog and add dark/light theme integration.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974d2250c4832cb14a2f9209fdd848