### PR TITLE
Remove header and footer animations

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,11 +46,12 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const animationToggle = document.getElementById('animation-toggle');
+  const glassElements = document.querySelectorAll('main .glass');
   let animationsEnabled = localStorage.getItem('animations') !== 'off';
 
   function enableAnimations() {
     document.body.classList.remove('no-animations');
-    document.querySelectorAll('.glass').forEach((el) => {
+    glassElements.forEach((el) => {
       el.classList.add('hidden');
       observer.observe(el);
       el.addEventListener('mousemove', handleMouseMove);
@@ -64,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function disableAnimations() {
     document.body.classList.add('no-animations');
     observer.disconnect();
-    document.querySelectorAll('.glass').forEach((el) => {
+    glassElements.forEach((el) => {
       el.classList.remove('hidden');
       el.classList.add('visible');
       el.removeEventListener('mousemove', handleMouseMove);

--- a/styles.css
+++ b/styles.css
@@ -72,7 +72,13 @@ header .contact {
   transform-style: preserve-3d;
 }
 
-.glass:hover {
+header.glass,
+footer.glass {
+  transition: none;
+  transform: none;
+}
+
+main .glass:hover {
   --hover-translate: -5px;
   --scale: 1.02;
   box-shadow: 0 12px 40px var(--glass-shadow);


### PR DESCRIPTION
## Summary
- prevent header and footer from participating in scroll or hover animations
- restrict animation logic to main content elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689750bfef3c832cae491e1a763c8a2b