### PR TITLE
Move water ripple effect behind panels

### DIFF
--- a/script.js
+++ b/script.js
@@ -34,12 +34,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const createRipple = (el) => {
     const ripple = document.createElement('span');
-    const size = Math.max(el.offsetWidth, el.offsetHeight);
+    const rect = el.getBoundingClientRect();
+    const size = Math.max(window.innerWidth, window.innerHeight) * 2;
     ripple.classList.add('ripple');
     ripple.style.width = ripple.style.height = `${size}px`;
-    ripple.style.left = `${(el.offsetWidth - size) / 2}px`;
-    ripple.style.top = `${(el.offsetHeight - size) / 2}px`;
-    el.appendChild(ripple);
+    ripple.style.left = `${rect.left + rect.width / 2 - size / 2}px`;
+    ripple.style.top = `${rect.top + rect.height / 2 - size / 2}px`;
+    document.body.appendChild(ripple);
     ripple.addEventListener('animationend', () => {
       ripple.remove();
     });

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,7 @@ header .contact {
   -webkit-backdrop-filter: blur(10px) saturate(180%);
   position: relative;
   overflow: hidden;
+  z-index: 1;
   --translateY: 0px;
   --hover-translate: 0px;
   --rotateX: 0deg;
@@ -85,17 +86,18 @@ main .glass:hover {
 }
 
 .ripple {
-  position: absolute;
+  position: fixed;
   border-radius: 50%;
   transform: scale(0);
   animation: ripple 0.6s linear;
   pointer-events: none;
   background: rgba(255, 255, 255, 0.5);
+  z-index: 0;
 }
 
 @keyframes ripple {
   to {
-    transform: scale(4);
+    transform: scale(1);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Render ripple animation behind panels by appending ripples to the body and sizing them to span the viewport
- Ensure panels stay above ripples with z-index and fixed positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689754839208832c8cd1ea3f6a76aef1