### PR TITLE
Enlarge disclaimer and let it scroll with page

### DIFF
--- a/script.js
+++ b/script.js
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const disclaimerModal = document.getElementById('disclaimer-modal');
   const disclaimerClose = document.getElementById('disclaimer-close');
   if (disclaimerModal) {
-    disclaimerModal.showModal();
+    disclaimerModal.show();
     disclaimerClose.addEventListener('click', () => disclaimerModal.close());
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -204,6 +204,12 @@ a:hover {
   box-shadow: 0 8px 32px var(--glass-shadow);
   backdrop-filter: blur(10px) saturate(180%);
   -webkit-backdrop-filter: blur(10px) saturate(180%);
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80%;
+  max-width: 500px;
 }
 
 #disclaimer-modal::backdrop {


### PR DESCRIPTION
## Summary
- make disclaimer modal larger and position it absolutely so it follows page scroll
- switch disclaimer from modal to non-modal so users can scroll the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689755180c2c832ca7e745ea67171289