### PR TITLE
fix: persist disclaimer acknowledgement

### DIFF
--- a/script.js
+++ b/script.js
@@ -110,9 +110,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const disclaimerModal = document.getElementById('disclaimer-modal');
   const disclaimerClose = document.getElementById('disclaimer-close');
-  if (disclaimerModal) {
-    disclaimerModal.show();
-    disclaimerClose.addEventListener('click', () => disclaimerModal.close());
+  const disclaimerAcknowledged = localStorage.getItem('disclaimerAcknowledged');
+  if (disclaimerModal && disclaimerAcknowledged !== 'true') {
+    disclaimerModal.showModal();
+    disclaimerClose.addEventListener('click', () => {
+      disclaimerModal.close();
+      localStorage.setItem('disclaimerAcknowledged', 'true');
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure disclaimer popup opens as modal and remembers user dismissal

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897571e3a74832c9a34d957b6ecf046