### PR TITLE
Center disclaimer modal and enable scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,9 @@ a:hover {
   transform: translate(-50%, -50%);
   width: 80%;
   max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+  margin: 0;
   z-index: 1001;
 }
 


### PR DESCRIPTION
## Summary
- Ensure disclaimer modal centers on screen
- Allow scrolling in the disclaimer modal for longer content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975c61f16c832ca102f27dd1c003e0