### PR TITLE
Apply disclaimer backdrop to page background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,20 @@ body {
   padding: 0;
   background: var(--bg-gradient);
   color: var(--text-color);
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: -1;
 }
 
 header {


### PR DESCRIPTION
## Summary
- Overlay page with the same dark, blurred backdrop used behind the disclaimer modal

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68975f89b96c832c901c948e39a7b987