### PR TITLE
Improve light theme background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: light;
-  --bg-gradient: linear-gradient(135deg, #f0f0f0 0%, #cccccc 100%);
+  --bg-gradient: linear-gradient(135deg, #ffffff 0%, #eaeaea 100%);
+  --overlay-color: rgba(255, 255, 255, 0.4);
   --text-color: #1e1e1e;
   --link-color: #1e88e5;
   --glass-bg: rgba(255, 255, 255, 0.6);
@@ -15,6 +16,7 @@
 [data-theme="dark"] {
   color-scheme: dark;
   --bg-gradient: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
+  --overlay-color: rgba(0, 0, 0, 0.5);
   --text-color: #f0f0f0;
   --link-color: #4dabf7;
   --glass-bg: rgba(0, 0, 0, 0.4);
@@ -44,7 +46,7 @@ body::before {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-color);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   z-index: -1;


### PR DESCRIPTION
## Summary
- soften light theme background gradient and overlay for a brighter appearance
- apply theme-specific overlay variable for light and dark modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689761a51f40832cb3232e5e646ad53d