### PR TITLE
Add professional roadmap page and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 </section>
 <section id="experience" class="glass">
   <h2>Professional Experience</h2>
+  <a href="professional-roadmap.html" class="roadmap-button">Professional Roadmap</a>
   <div class="job">
     <h3>Senior Product Owner | Jets Better</h3>
     <span class="date">Feb 2025 – Present</span>

--- a/professional-roadmap.html
+++ b/professional-roadmap.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Professional Roadmap - Ilya Zubkov</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
+  <script>
+    const storedTheme = localStorage.getItem('theme');
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', storedTheme || systemTheme);
+  </script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<button id="theme-toggle" aria-label="Toggle dark/light mode">🌙</button>
+<button id="animation-toggle" aria-label="Toggle animations">💫</button>
+<header class="glass">
+  <div class="container">
+    <h1>Professional Roadmap</h1>
+  </div>
+</header>
+<main class="container">
+  <section class="glass">
+    <h2>Professional Roadmap</h2>
+    <p>Below is a quick overview of my career progression and future goals.</p>
+    <ul>
+      <li>2025: Senior Product Owner at Jets Better</li>
+      <li>2024: Product Owner at Binary Studio</li>
+      <li>2023: Technical Project Manager at Prof-IT Blockchain</li>
+      <li>2021: Junior Software Engineer at Playbatch</li>
+    </ul>
+  </section>
+</main>
+<footer class="glass">
+  <div class="container">
+    <p>&copy; 2025 Ilya Zubkov</p>
+  </div>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>
+

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,23 @@ a:hover {
   box-shadow: 0 6px 20px var(--glass-shadow);
 }
 
+.roadmap-button {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 5px 15px;
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  background: var(--glass-bg);
+  color: var(--text-color);
+  cursor: pointer;
+  box-shadow: 0 4px 12px var(--glass-shadow);
+  text-decoration: none;
+}
+
+.roadmap-button:hover {
+  box-shadow: 0 6px 20px var(--glass-shadow);
+}
+
 .no-animations .glass {
   transition: none !important;
   transform: none !important;


### PR DESCRIPTION
## Summary
- Link Professional Experience section to a new Professional Roadmap page.
- Style a new roadmap button and present roadmap details on its own page.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/CV/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68987506c430832c9d4bcedc8919875b