### PR TITLE
Improve Professional Roadmap button visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -239,13 +239,16 @@ a:hover {
 }
 
 .roadmap-button {
+  position: absolute;
+  top: 20px;
+  right: 20px;
   display: inline-block;
-  margin-top: 10px;
-  padding: 5px 15px;
-  border: 1px solid var(--glass-border);
+  padding: 8px 16px;
+  border: none;
   border-radius: 8px;
-  background: var(--glass-bg);
-  color: var(--text-color);
+  background: var(--link-color);
+  color: #fff;
+  font-weight: 700;
   cursor: pointer;
   box-shadow: 0 4px 12px var(--glass-shadow);
   text-decoration: none;
@@ -253,6 +256,7 @@ a:hover {
 
 .roadmap-button:hover {
   box-shadow: 0 6px 20px var(--glass-shadow);
+  filter: brightness(1.1);
 }
 
 .no-animations .glass {


### PR DESCRIPTION
## Summary
- Reposition Professional Roadmap button to the top-right corner of the experience panel
- Increase button prominence with accent color, bold text, and hover highlight

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689877d8d1a4832ca801605867465e11