### PR TITLE
Expand Playbatch timeline on roadmap page

### DIFF
--- a/professional-roadmap.html
+++ b/professional-roadmap.html
@@ -115,22 +115,57 @@
         <h2>Playbatch</h2>
         <div class="project">
           <div class="project-header">
-            <h3>Game Analytics Dashboard</h3>
-            <span class="project-duration">Mar 2021 - Aug 2021</span>
+            <h3>Mini-Pool Analytics Integration</h3>
+            <span class="project-duration">Oct 2021 – Dec 2021</span>
           </div>
           <p>
-            Developed frontend components for an internal dashboard, working
-            with designers and backend engineers as Junior Software Engineer.
+            Integrated Amplitude and Singular analytics into the mini-pool test
+            application and published the app to the App Store and Google Play
+            via automated build pipelines.
           </p>
         </div>
         <div class="project">
           <div class="project-header">
-            <h3>Automated Build Pipeline</h3>
-            <span class="project-duration">Sep 2021 - Dec 2021</span>
+            <h3>Magic Matter Core Development</h3>
+            <span class="project-duration">Jan 2022 – Jun 2022</span>
           </div>
           <p>
-            Implemented a CI/CD pipeline to automate builds and deployments,
-            reducing release time.
+            Implemented a robust sound system and advanced analytics and event
+            tracking while collaborating with cross-functional teams to enhance
+            gameplay.
+          </p>
+        </div>
+        <div class="project">
+          <div class="project-header">
+            <h3>Master Lily Hyper-Casual Game</h3>
+            <span class="project-duration">Jul 2022 – Sep 2022</span>
+          </div>
+          <p>
+            Led development of the hyper-casual game from concept to launch,
+            partnering closely with the design team to pioneer rapid prototyping
+            and iterative gameplay mechanics.
+          </p>
+        </div>
+        <div class="project">
+          <div class="project-header">
+            <h3>Hyper-Casual Concept Explorations</h3>
+            <span class="project-duration">Oct 2022 – Nov 2022</span>
+          </div>
+          <p>
+            Explored Minesweeper-inspired Crocodile Swampy and picture-assembly
+            puzzle concepts, strengthening algorithmic problem-solving under the
+            mentorship of senior developers.
+          </p>
+        </div>
+        <div class="project">
+          <div class="project-header">
+            <h3>Bubble-Buster Mini-Game</h3>
+            <span class="project-duration">Dec 2022 – Mar 2023</span>
+          </div>
+          <p>
+            Developed a bubble-buster-style mini-game within the Magic Matter
+            realm, delivering engaging mechanics and maintaining high code
+            quality through rigorous testing and optimization.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Replace placeholder Playbatch section with detailed timeline highlighting analytics integration, Magic Matter contributions, and hyper-casual game projects.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898887edb64832c80220e2973b1d1c2