### PR TITLE
feat: show company start dates in roadmap

### DIFF
--- a/professional-roadmap.html
+++ b/professional-roadmap.html
@@ -41,6 +41,7 @@
 
       <section class="glass company-panel">
         <h2>Jets Better</h2>
+        <span class="company-start-date">Feb 2025</span>
         <div class="project">
           <div class="project-header">
             <h3>JetApp Mobile Revamp</h3>
@@ -65,6 +66,7 @@
 
       <section class="glass company-panel">
         <h2>Binary Studio</h2>
+        <span class="company-start-date">Apr 2024</span>
         <div class="project">
           <div class="project-header">
             <h3>E-commerce Analytics Dashboard</h3>
@@ -89,6 +91,7 @@
 
       <section class="glass company-panel">
         <h2>Prof-IT Blockchain</h2>
+        <span class="company-start-date">Apr 2023</span>
         <div class="project">
           <div class="project-header">
             <h3>DeFi Wallet Launch</h3>
@@ -113,6 +116,7 @@
 
       <section class="glass company-panel">
         <h2>Playbatch</h2>
+        <span class="company-start-date">Oct 2021</span>
         <div class="project">
           <div class="project-header">
             <h3>Mini-Pool Analytics Integration</h3>

--- a/styles.css
+++ b/styles.css
@@ -261,6 +261,15 @@ a:hover {
 
   .company-panel {
     margin-top: 40px;
+    position: relative;
+  }
+
+  .company-start-date {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 0.9em;
+    color: var(--date-color);
   }
 
   .project {


### PR DESCRIPTION
## Summary
- display each company's start date at the top-right of its panel in the professional roadmap
- style the new start-date labels for consistent placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988caae5a4832cb2d1c262e483272b