### PR TITLE
Add end dates to professional roadmap sections

### DIFF
--- a/professional-roadmap.html
+++ b/professional-roadmap.html
@@ -41,7 +41,7 @@
 
       <section class="glass company-panel">
         <h2>Jets Better</h2>
-        <span class="company-start-date">Feb 2025</span>
+        <span class="company-dates">Feb 2025 – Present</span>
         <div class="project">
           <div class="project-header">
             <h3>JetApp Mobile Revamp</h3>
@@ -66,7 +66,7 @@
 
       <section class="glass company-panel">
         <h2>Binary Studio</h2>
-        <span class="company-start-date">Apr 2024</span>
+        <span class="company-dates">Apr 2024 – Aug 2024</span>
         <div class="project">
           <div class="project-header">
             <h3>E-commerce Analytics Dashboard</h3>
@@ -91,7 +91,7 @@
 
       <section class="glass company-panel">
         <h2>Prof-IT Blockchain</h2>
-        <span class="company-start-date">Apr 2023</span>
+        <span class="company-dates">Apr 2023 – Feb 2024</span>
         <div class="project">
           <div class="project-header">
             <h3>DeFi Wallet Launch</h3>
@@ -116,7 +116,7 @@
 
       <section class="glass company-panel">
         <h2>Playbatch</h2>
-        <span class="company-start-date">Oct 2021</span>
+        <span class="company-dates">Oct 2021 – Mar 2023</span>
         <div class="project">
           <div class="project-header">
             <h3>Mini-Pool Analytics Integration</h3>

--- a/styles.css
+++ b/styles.css
@@ -264,7 +264,7 @@ a:hover {
     position: relative;
   }
 
-  .company-start-date {
+  .company-dates {
     position: absolute;
     top: 20px;
     right: 20px;


### PR DESCRIPTION
## Summary
- Display both start and end dates for each company in the professional roadmap
- Rename style class to support date ranges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989044ab8c832cba73a9e8d5ecb1a7